### PR TITLE
Created a check for /usr/local/sbin

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -5,3 +5,7 @@ set -e
 if ! which -s ngircd; then
   brew install ngircd
 fi
+
+if !(echo $PATH | grep '/usr/local/sbin') ; then
+    echo "You don't have /usr/local/sbin/ in your $PATH, you should add it so the server script will work"
+fi


### PR DESCRIPTION
It seems ngircd puts it's binary in /usr/local/sbin not bin,
if it's not part of your path you can't run the server script.
